### PR TITLE
Feat/remixes

### DIFF
--- a/src/app/remix-form/page.tsx
+++ b/src/app/remix-form/page.tsx
@@ -42,6 +42,7 @@ import {
   ImageIcon,
   Save,
   LinkIcon,
+  AlertCircle,
 } from "lucide-react";
 import { registerStoryAsIP } from "../../services/storyService";
 import { uploadStoryToPinata } from "../../utils/pinata";
@@ -117,8 +118,8 @@ interface Step {
 const remixSteps: Step[] = [
   {
     id: 1,
-    title: "Choose License",
-    description: "Select how you want to license your remix",
+    title: "License Inheritance",
+    description: "Review inherited license terms from parent IP",
     icon: Scale,
     schema: licenseSchema,
   },
@@ -608,127 +609,96 @@ export default function RemixStoryForm({
                 </div>
               )}
 
-              {/* Step 1: License Selection */}
+              {/* Step 1: License Inheritance (View-Only) */}
               {currentStep === 1 && (
                 <div className="space-y-6">
-                  <FormField
-                    control={form.control}
-                    name="licenseType"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>License Type for Your Remix</FormLabel>
-                        {originalStory && (
-                          <div className="mb-4 p-4 bg-gradient-to-r from-blue-50 to-indigo-50 border border-blue-200 rounded-lg">
-                            <div className="flex items-start gap-3">
-                              <LinkIcon className="h-5 w-5 text-blue-600 mt-0.5 flex-shrink-0" />
-                              <div className="space-y-2">
-                                <div className="text-sm font-medium text-blue-900">
-                                  License Inheritance
-                                </div>
-                                <div className="text-sm text-blue-800">
-                                  Your remix will automatically inherit the <strong>"{(originalStory as { licenseType?: string })?.licenseType || 'non-commercial'}"</strong> license from the original story <strong>"{(originalStory as { title: string }).title}"</strong> by <strong>{(originalStory as { author: string }).author}</strong>.
-                                </div>
-                                <div className="text-xs text-blue-600">
-                                  This ensures proper attribution and maintains the licensing chain for derivative works.
-                                </div>
-                              </div>
+                  {originalStory && (
+                    <div className="space-y-4">
+                      <div className="p-6 bg-gradient-to-r from-blue-50 to-indigo-50 border border-blue-200 rounded-lg">
+                        <div className="flex items-start gap-4">
+                          <div className="p-2 bg-blue-100 rounded-lg">
+                            <LinkIcon className="h-6 w-6 text-blue-600" />
+                          </div>
+                          <div className="space-y-3 flex-1">
+                            <div className="text-lg font-semibold text-blue-900">
+                              License Automatically Inherited
+                            </div>
+                            <div className="text-sm text-blue-800 leading-relaxed">
+                              As per Story Protocol, your remix will automatically inherit all license terms, royalty rules, and dispute statuses from the parent IP asset. These terms cannot be modified.
                             </div>
                           </div>
+                        </div>
+                      </div>
+
+                      <div className="p-6 border border-gray-200 rounded-lg bg-gray-50">
+                        <h3 className="text-lg font-semibold mb-4 text-gray-900">Inherited License Terms</h3>
+                        
+                        <div className="space-y-4">
+                          <div className="flex items-center justify-between p-4 bg-white border border-gray-200 rounded-lg">
+                            <div className="space-y-1">
+                              <div className="font-medium text-gray-900">Parent Story</div>
+                              <div className="text-sm text-gray-600">"{(originalStory as { title: string }).title}" by {(originalStory as { author: string }).author}</div>
+                            </div>
+                            <Badge variant="outline" className="bg-blue-50 text-blue-700 border-blue-200">
+                              Original
+                            </Badge>
+                          </div>
+
+                          <div className="flex items-center justify-center">
+                            <div className="w-px h-8 bg-gray-300"></div>
+                          </div>
+
+                          <div className="flex items-center justify-between p-4 bg-white border-2 border-blue-200 rounded-lg">
+                            <div className="space-y-1">
+                              <div className="font-medium text-gray-900">Your Remix</div>
+                              <div className="text-sm text-gray-600">Will inherit all terms from parent</div>
+                            </div>
+                            <Badge className="bg-blue-100 text-blue-800 border-blue-300">
+                              {((originalStory as { licenseType?: string })?.licenseType || 'non-commercial')
+                                .split('-')
+                                .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+                                .join(' ')}
+                            </Badge>
+                          </div>
+                        </div>
+
+                        <div className="mt-6 p-4 bg-amber-50 border border-amber-200 rounded-lg">
+                          <div className="flex items-start gap-3">
+                            <div className="p-1 bg-amber-100 rounded">
+                              <AlertCircle className="h-4 w-4 text-amber-600" />
+                            </div>
+                            <div className="text-sm text-amber-800">
+                              <strong>Important:</strong> License terms are automatically inherited and cannot be changed. This ensures compliance with Story Protocol and maintains the integrity of the IP lineage chain.
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* Hidden form field to store the inherited license */}
+                      <FormField
+                        control={form.control}
+                        name="licenseType"
+                        render={({ field }) => (
+                          <input
+                            type="hidden"
+                            value={field.value}
+                            onChange={field.onChange}
+                          />
                         )}
-                        <FormControl>
-                          <div className="space-y-4">
-                            <div className="grid gap-4">
-                              <label
-                                className={`flex items-start gap-3 p-4 border rounded-lg cursor-pointer hover:bg-muted/50 w-full overflow-hidden ${
-                                  field.value === "non-commercial"
-                                    ? "border-primary bg-primary/5"
-                                    : ""
-                                }`}
-                              >
-                                <input
-                                  type="radio"
-                                  value="non-commercial"
-                                  checked={field.value === "non-commercial"}
-                                  onChange={field.onChange}
-                                  className="mt-1 flex-shrink-0"
-                                />
-                                <div className="space-y-2 min-w-0 flex-1 overflow-hidden">
-                                  <div className="font-medium">
-                                    Non-Commercial Remix License
-                                  </div>
-                                  <div className="text-sm text-muted-foreground">
-                                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.
-                                  </div>
-                                  <Badge variant="secondary" className="text-xs">
-                                    Ideal for: Creative experimentation and community building
-                                  </Badge>
-                                </div>
-                              </label>
+                      />
+                    </div>
+                  )}
 
-                              <label
-                                className={`flex items-start gap-3 p-4 border rounded-lg cursor-pointer hover:bg-muted/50 w-full overflow-hidden ${
-                                  field.value === "commercial-use"
-                                    ? "border-primary bg-primary/5"
-                                    : ""
-                                }`}
-                              >
-                                <input
-                                  type="radio"
-                                  value="commercial-use"
-                                  checked={field.value === "commercial-use"}
-                                  onChange={field.onChange}
-                                  className="mt-1 flex-shrink-0"
-                                />
-                                <div className="space-y-2 min-w-0 flex-1 overflow-hidden">
-                                  <div className="font-medium">
-                                    Commercial Use License
-                                  </div>
-                                  <div className="text-sm text-muted-foreground">
-                                    Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-                                  </div>
-                                  <Badge variant="secondary" className="text-xs">
-                                    Ideal for: Professional remixes with commercial potential
-                                  </Badge>
-                                </div>
-                              </label>
-
-                              <label
-                                className={`flex items-start gap-3 p-4 border rounded-lg cursor-pointer hover:bg-muted/50 w-full overflow-hidden ${
-                                  field.value === "commercial-remix"
-                                    ? "border-primary bg-primary/5"
-                                    : ""
-                                }`}
-                              >
-                                <input
-                                  type="radio"
-                                  value="commercial-remix"
-                                  checked={field.value === "commercial-remix"}
-                                  onChange={field.onChange}
-                                  className="mt-1 flex-shrink-0"
-                                />
-                                <div className="space-y-2 min-w-0 flex-1 overflow-hidden">
-                                  <div className="font-medium">
-                                    Commercial Remix License
-                                  </div>
-                                  <div className="text-sm text-muted-foreground">
-                                    Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia.
-                                  </div>
-                                  <Badge variant="secondary" className="text-xs">
-                                    Ideal for: Remixes intended for broad commercial distribution
-                                  </Badge>
-                                </div>
-                              </label>
-                            </div>
-                          </div>
-                        </FormControl>
-                        <FormDescription>
-                          Choose how others can use your remix. This will be
-                          enforced on-chain through Story Protocol.
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
+                  {!originalStory && (
+                    <div className="p-6 border border-red-200 bg-red-50 rounded-lg">
+                      <div className="flex items-center gap-3">
+                        <AlertCircle className="h-5 w-5 text-red-600" />
+                        <div className="text-sm text-red-800">
+                          Unable to load parent story information. Please try again or contact support.
+                        </div>
+                      </div>
+                    </div>
+                  )}
                 </div>
               )}
 

--- a/src/app/stories/[ipId]/page.tsx
+++ b/src/app/stories/[ipId]/page.tsx
@@ -376,6 +376,58 @@ const ReaderPage = () => {
     return assetData.childrenCount;
   };
 
+  // Get lineage information
+  const getLineageInfo = () => {
+    if (assetError || !assetData) return null;
+    return {
+      isOriginal: assetData.parentCount === 0,
+      isRemix: assetData.parentCount > 0,
+      parentCount: assetData.parentCount,
+      childrenCount: assetData.childrenCount,
+      totalConnected: assetData.parentCount + assetData.childrenCount
+    };
+  };
+
+  // Find connected works from store and user data
+  const getConnectedWorks = () => {
+    const connected = {
+      parents: [] as any[],
+      children: [] as any[]
+    };
+
+    // Find children (remixes of this story)
+    const allStories = [
+      ...publishedStories,
+      ...users.flatMap(user => 
+        user.stories
+          .filter(story => story.ipId && story.title)
+          .map(story => ({
+            ...story,
+            author: { name: user.userName || user.walletAddress.slice(0, 8) + "...", address: user.walletAddress }
+          }))
+      )
+    ];
+
+    // Find stories that have this story as their original
+    connected.children = allStories.filter(story => 
+      (story as any).originalStoryId === ipId
+    );
+
+    // Find parent story if this is a remix
+    const currentStoryInStore = publishedStories.find(s => s.ipId === ipId);
+    if (currentStoryInStore?.originalStoryId) {
+      const parentStory = allStories.find(s => s.ipId === currentStoryInStore.originalStoryId);
+      if (parentStory) {
+        connected.parents.push(parentStory);
+      }
+    }
+
+    return connected;
+  };
+
+  const lineageInfo = getLineageInfo();
+  const connectedWorks = getConnectedWorks();
+
   if (loading) {
     return (
       <div className='min-h-screen flex items-center justify-center'>
@@ -467,32 +519,128 @@ const ReaderPage = () => {
                 </div>
                 <h3 className='text-xl font-semibold mb-4'>{story.author}</h3>
 
-                <div className='mb-4'>
-                  {assetLoading ? (
-                    <div className='bg-muted/20 border border-muted/40 rounded-xl px-4 py-3 text-muted-foreground text-sm font-medium'>
-                      <Loader2 className='h-4 w-4 inline mr-2 animate-spin' />
-                      Loading...
-                    </div>
-                  ) : assetError ? (
-                    <div className='bg-destructive/20 border border-destructive/40 rounded-xl px-4 py-3 text-destructive text-sm font-medium'>
-                      Failed to load
-                    </div>
-                  ) : (
-                    <div
-                      className={`border rounded-xl px-4 py-3 text-sm font-medium ${
-                        assetData?.parentCount === 0
-                          ? "bg-emerald-500/20 border-emerald-500/40 text-emerald-400"
-                          : "bg-blue-500/20 border-blue-500/40 text-blue-400"
-                      }`}
-                    >
-                      {getOriginStatus()}
-                    </div>
-                  )}
-                </div>
+                <div className='space-y-4'>
+                  {/* Lineage Status */}
+                  <div className='mb-4'>
+                    {assetLoading ? (
+                      <div className='bg-muted/20 border border-muted/40 rounded-xl px-4 py-3 text-muted-foreground text-sm font-medium'>
+                        <Loader2 className='h-4 w-4 inline mr-2 animate-spin' />
+                        Loading lineage...
+                      </div>
+                    ) : assetError ? (
+                      <div className='bg-destructive/20 border border-destructive/40 rounded-xl px-4 py-3 text-destructive text-sm font-medium'>
+                        Failed to load lineage
+                      </div>
+                    ) : lineageInfo ? (
+                      <div className='space-y-3'>
+                        <div
+                          className={`border rounded-xl px-4 py-3 text-sm font-medium ${
+                            lineageInfo.isOriginal
+                              ? "bg-emerald-500/20 border-emerald-500/40 text-emerald-400"
+                              : "bg-blue-500/20 border-blue-500/40 text-blue-400"
+                          }`}
+                        >
+                          {lineageInfo.isOriginal ? "Original Work" : "Remix"}
+                        </div>
+                        
+                        {lineageInfo.isRemix && (
+                          <div className='bg-amber-500/10 border border-amber-500/30 rounded-xl px-4 py-3 text-amber-600 text-sm'>
+                            Derived from {lineageInfo.parentCount} parent work{lineageInfo.parentCount !== 1 ? 's' : ''}
+                          </div>
+                        )}
+                      </div>
+                    ) : null}
+                  </div>
 
-                <div className='bg-primary/10 border border-primary/30 rounded-xl px-4 py-3 text-primary text-sm'>
-                  Connected works: {getConnectedWorksCount()}
+                  {/* Connected Works Summary */}
+                  <div className='bg-primary/10 border border-primary/30 rounded-xl px-4 py-3 text-primary text-sm'>
+                    <div className='font-medium mb-1'>Connected Works</div>
+                    <div className='text-xs opacity-80'>
+                      {lineageInfo ? `${lineageInfo.totalConnected} total connections` : 'Loading...'}
+                    </div>
+                  </div>
                 </div>
+              </CardContent>
+            </Card>
+
+            {/* Connected Works Lineage */}
+            <Card className='bg-card border-primary/30 backdrop-blur-lg'>
+              <CardContent className='p-6'>
+                <h4 className='text-xl font-semibold mb-6 text-primary flex items-center gap-2'>
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                  </svg>
+                  Connected Works
+                </h4>
+                
+                {lineageInfo && lineageInfo.totalConnected > 0 ? (
+                  <div className='space-y-4'>
+                    {/* Parent Works */}
+                    {connectedWorks.parents.length > 0 && (
+                      <div className='space-y-3'>
+                        <h5 className='text-sm font-medium text-muted-foreground uppercase tracking-wide'>
+                          Parent Works ({connectedWorks.parents.length})
+                        </h5>
+                        {connectedWorks.parents.map((parent, index) => (
+                          <div key={index} className='flex items-center gap-3 p-3 bg-blue-50 border border-blue-200 rounded-lg'>
+                            <div className='w-2 h-2 bg-blue-500 rounded-full'></div>
+                            <div className='flex-1'>
+                              <div className='font-medium text-sm'>{parent.title}</div>
+                              <div className='text-xs text-muted-foreground'>by {parent.author?.name || parent.author}</div>
+                            </div>
+                            <Badge variant="outline" className="text-xs">Original</Badge>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+
+                    {/* Current Work */}
+                    <div className='space-y-3'>
+                      <h5 className='text-sm font-medium text-muted-foreground uppercase tracking-wide'>
+                        Current Work
+                      </h5>
+                      <div className='flex items-center gap-3 p-3 bg-primary/10 border-2 border-primary/30 rounded-lg'>
+                        <div className='w-2 h-2 bg-primary rounded-full'></div>
+                        <div className='flex-1'>
+                          <div className='font-medium text-sm'>{story.title}</div>
+                          <div className='text-xs text-muted-foreground'>by {story.author}</div>
+                        </div>
+                        <Badge className="text-xs">
+                          {lineageInfo.isOriginal ? "Original" : "Remix"}
+                        </Badge>
+                      </div>
+                    </div>
+
+                    {/* Child Works */}
+                    {connectedWorks.children.length > 0 && (
+                      <div className='space-y-3'>
+                        <h5 className='text-sm font-medium text-muted-foreground uppercase tracking-wide'>
+                          Derivative Works ({connectedWorks.children.length})
+                        </h5>
+                        {connectedWorks.children.map((child, index) => (
+                          <div key={index} className='flex items-center gap-3 p-3 bg-green-50 border border-green-200 rounded-lg'>
+                            <div className='w-2 h-2 bg-green-500 rounded-full'></div>
+                            <div className='flex-1'>
+                              <div className='font-medium text-sm'>{child.title}</div>
+                              <div className='text-xs text-muted-foreground'>by {child.author?.name || child.author}</div>
+                            </div>
+                            <Badge variant="secondary" className="text-xs">Remix</Badge>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <div className='text-center py-8 text-muted-foreground'>
+                    <div className='w-16 h-16 mx-auto mb-4 bg-muted/20 rounded-full flex items-center justify-center'>
+                      <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                      </svg>
+                    </div>
+                    <p className='text-sm'>No connected works found</p>
+                    <p className='text-xs mt-1'>This story has no parent or derivative works yet</p>
+                  </div>
+                )}
               </CardContent>
             </Card>
 

--- a/src/app/stories/page.tsx
+++ b/src/app/stories/page.tsx
@@ -3,7 +3,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { BookOpen, User, FileText, Globe, AlertCircle } from "lucide-react";
+import { BookOpen, User, FileText, Globe, AlertCircle, GitBranch, Sparkles } from "lucide-react";
 import { users } from "../../data/user";
 import { useStoryStore } from "../../stores/storyStore";
 import Link from "next/link";
@@ -37,7 +37,9 @@ export default function StoriesPage() {
     author: story.author.name || story.author.address.slice(0, 8) + "...",
     authorAddress: story.author.address,
     publishedAt: story.publishedAt,
-    licenseType: story.licenseType,
+    licenseType: story.licenseTypes?.[0] || 'non-commercial',
+    originalStoryId: story.originalStoryId, // Track remix relationship
+    isRemix: !!story.originalStoryId, // Flag to identify remixes
   }));
 
   // Combine and deduplicate stories (store stories take precedence)
@@ -96,13 +98,27 @@ export default function StoriesPage() {
               )}
 
               <CardHeader className='flex-1'>
-                <CardTitle className='line-clamp-2'>
-                  {story.title || "Untitled Story"}
-                </CardTitle>
+                <div className="flex items-start justify-between gap-2">
+                  <CardTitle className='line-clamp-2 flex-1'>
+                    {story.title || "Untitled Story"}
+                  </CardTitle>
+                  {(story as any).isRemix && (
+                    <Badge variant="secondary" className="flex items-center gap-1 text-xs">
+                      <GitBranch className="h-3 w-3" />
+                      Remix
+                    </Badge>
+                  )}
+                </div>
                 {story.synopsis && (
                   <p className='text-sm text-muted-foreground line-clamp-3'>
                     {story.synopsis}
                   </p>
+                )}
+                {(story as any).isRemix && (
+                  <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                    <Sparkles className="h-3 w-3" />
+                    <span>Remix of original work</span>
+                  </div>
                 )}
               </CardHeader>
 

--- a/src/services/storyService.ts
+++ b/src/services/storyService.ts
@@ -40,6 +40,7 @@ export interface StoryRegistrationResult {
 
 /**
  * Register a story as an IP asset using the Story Protocol API
+ * Handles both original stories and remixes (derivatives)
  */
 export async function registerStoryAsIP(
   data: StoryRegistrationData
@@ -47,86 +48,166 @@ export async function registerStoryAsIP(
   try {
     console.log("Registering story as IP:", data.title);
 
-    // Handle both single license type (remix) and multiple license types (original story)
-    let licenseTypes: ("non-commercial" | "commercial-use" | "commercial-remix")[];
-    
-    if (data.licenseType) {
-      // Single license type (typically for remixes)
-      licenseTypes = [data.licenseType];
-    } else if (data.licenseTypes && data.licenseTypes.length > 0) {
-      // Multiple license types (typically for original stories)
-      licenseTypes = data.licenseTypes;
+    // Check if this is a remix (derivative)
+    const isRemix = !!data.originalStoryId;
+
+    if (isRemix) {
+      console.log("Registering as derivative of:", data.originalStoryId);
+      return await registerDerivativeStory(data);
     } else {
-      throw new Error("At least one license type must be provided");
+      console.log("Registering as original story");
+      return await registerOriginalStory(data);
     }
-
-    if (licenseTypes.length > 3) {
-      throw new Error("Maximum 3 license types allowed");
-    }
-
-    // Validate individual license types
-    const validLicenseTypes = [
-      "non-commercial",
-      "commercial-use",
-      "commercial-remix",
-    ];
-    const invalidLicenses = licenseTypes.filter(
-      (type) => !validLicenseTypes.includes(type)
-    );
-    if (invalidLicenses.length > 0) {
-      throw new Error(`Invalid license types: ${invalidLicenses.join(", ")}`);
-    }
-
-    // Check for duplicates
-    const uniqueLicenses = [...new Set(licenseTypes)];
-    if (uniqueLicenses.length !== licenseTypes.length) {
-      console.warn("Duplicate license types detected, removing duplicates");
-      licenseTypes = uniqueLicenses;
-    }
-
-    const response = await fetch("/api/register-story", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        ...data,
-        licenseTypes: licenseTypes,
-      }),
-    });
-
-    if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(
-        errorData.error || `HTTP error! status: ${response.status}`
-      );
-    }
-
-    const result = await response.json();
-
-    if (!result.success) {
-      throw new Error(result.error || "Story registration failed");
-    }
-
-    console.log("Story registered successfully:", result.ipId);
-
-    return {
-      success: true,
-      ipId: result.ipId,
-      txHash: result.txHash,
-      licenseTermsIds: result.licenseTermsIds,
-      tokenId: result.tokenId,
-      storyData: result.storyData,
-      explorerUrl: result.explorerUrl,
-    };
   } catch (error) {
     console.error("Story registration error:", error);
-
     return {
       success: false,
       error: error instanceof Error ? error.message : "Unknown error occurred",
     };
   }
+}
+
+/**
+ * Register an original story
+ */
+async function registerOriginalStory(
+  data: StoryRegistrationData
+): Promise<StoryRegistrationResult> {
+  // Handle both single license type and multiple license types for original stories
+  let licenseTypes: ("non-commercial" | "commercial-use" | "commercial-remix")[];
+  
+  if (data.licenseType) {
+    licenseTypes = [data.licenseType];
+  } else if (data.licenseTypes && data.licenseTypes.length > 0) {
+    licenseTypes = data.licenseTypes;
+  } else {
+    throw new Error("At least one license type must be provided");
+  }
+
+  if (licenseTypes.length > 3) {
+    throw new Error("Maximum 3 license types allowed");
+  }
+
+  // Validate individual license types
+  const validLicenseTypes = [
+    "non-commercial",
+    "commercial-use",
+    "commercial-remix",
+  ];
+  const invalidLicenses = licenseTypes.filter(
+    (type) => !validLicenseTypes.includes(type)
+  );
+  if (invalidLicenses.length > 0) {
+    throw new Error(`Invalid license types: ${invalidLicenses.join(", ")}`);
+  }
+
+  // Check for duplicates
+  const uniqueLicenses = [...new Set(licenseTypes)];
+  if (uniqueLicenses.length !== licenseTypes.length) {
+    console.warn("Duplicate license types detected, removing duplicates");
+    licenseTypes = uniqueLicenses;
+  }
+
+  const response = await fetch("/api/register-story", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      ...data,
+      licenseTypes: licenseTypes,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(
+      errorData.error || `HTTP error! status: ${response.status}`
+    );
+  }
+
+  const result = await response.json();
+
+  if (!result.success) {
+    throw new Error(result.error || "Story registration failed");
+  }
+
+  console.log("Original story registered successfully:", result.ipId);
+
+  return {
+    success: true,
+    ipId: result.ipId,
+    txHash: result.txHash,
+    licenseTermsIds: result.licenseTermsIds,
+    tokenId: result.tokenId,
+    storyData: result.storyData,
+    explorerUrl: result.explorerUrl,
+  };
+}
+
+/**
+ * Register a derivative story (remix)
+ */
+async function registerDerivativeStory(
+  data: StoryRegistrationData
+): Promise<StoryRegistrationResult> {
+  if (!data.originalStoryId) {
+    throw new Error("Original story ID is required for derivative registration");
+  }
+
+  if (!data.licenseType) {
+    throw new Error("License type is required for derivative registration");
+  }
+
+  // Get the parent's license terms ID based on the license type
+  const parentLicenseTermsId = getLicenseTermsIdFromType(data.licenseType);
+  
+  if (!parentLicenseTermsId) {
+    throw new Error(`Invalid license type: ${data.licenseType}`);
+  }
+
+  // For derivatives, both parent and derivative should have the same license terms
+  const response = await fetch("/api/register-derivative", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      title: data.title,
+      description: data.description,
+      contentCID: data.contentCID,
+      imageCID: data.imageCID,
+      author: data.author,
+      parentIpId: data.originalStoryId,
+      parentLicenseTermsId: parentLicenseTermsId,
+      derivativeLicenseType: data.licenseType,
+    }),
+  });
+
+    if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(
+      errorData.error || `HTTP error! status: ${response.status}`
+    );
+  }
+
+  const result = await response.json();
+
+  if (!result.success) {
+    throw new Error(result.error || "Derivative registration failed");
+  }
+
+  console.log("Derivative story registered successfully:", result.ipId);
+
+  return {
+    success: true,
+    ipId: result.ipId,
+    txHash: result.txHash,
+    licenseTermsIds: result.licenseTermsIds,
+    tokenId: result.tokenId,
+    storyData: result.derivativeData,
+    explorerUrl: result.explorerUrl,
+  };
 }
 
 /**
@@ -180,4 +261,20 @@ export async function getUserStories(userAddress: Address): Promise<any[]> {
   // TODO: Implement user story listing
   console.log("Getting stories for user:", userAddress);
   return [];
+}
+
+/**
+ * Get license terms ID from license type
+ */
+function getLicenseTermsIdFromType(licenseType: "non-commercial" | "commercial-use" | "commercial-remix"): string {
+  switch (licenseType) {
+    case "non-commercial":
+      return "1"; // NonCommercialSocialRemixingTermsId
+    case "commercial-use":
+      return "2"; // CommercialUseOnlyTermsId
+    case "commercial-remix":
+      return "3"; // CommercialRemixTermsId
+    default:
+      throw new Error(`Unknown license type: ${licenseType}`);
+  }
 }


### PR DESCRIPTION
Enabled derivative story support with adaptive remix form and license controls

Key points:
- Retained the established author, title, and synopsis layout from `main` for consistency.
- Incorporated the remix badge and "Remix of original work" indicator from `feat/remixes` to clearly mark derivative stories.
- Ensured the remix indicators do not disrupt the existing design flow or user experience.
- Cleaned up conflicting code and removed merge markers.

This approach prioritizes the enhanced remix functionality while maintaining UI clarity and consistency across published stories.

---

**Testing:**
- Verified remix badges appear correctly on remixed stories.
- Checked that author info and synopsis display as before.
- Confirmed no layout regressions or visual glitches occur on desktop and mobile views.